### PR TITLE
remove svg.path dependency

### DIFF
--- a/pysrc/requirements.txt
+++ b/pysrc/requirements.txt
@@ -1,3 +1,2 @@
-svg.path==3.0
 svgpathtools==1.3.3
 numpy

--- a/pysrc/svg_load/SvgLoader.py
+++ b/pysrc/svg_load/SvgLoader.py
@@ -11,12 +11,12 @@ def load_svg(filename):
 
     hex_color = re.search("stroke:#(([0-9]|[A-F]|[a-f]){6});?", attributes[0]["style"])[1]
     rgb_color = tuple(bytearray.fromhex(hex_color))
-    return paths[0].d(), rgb_color
+    return paths[0], rgb_color
 
 
 if __name__ == "__main__":
-    file_name = "fairydustb.svg"
-    from pysrc.path2polygon import path2polygonPoints, print_samples
+    file_name = "../fairydustb.svg_load"
+    from pysrc.svg_load.path2polygon import path2polygonPoints, print_samples
     path, (r, g, b) = load_svg(file_name)
     # print(f"r:{r}, g:{g}, b:{b}, path: {path}")
     points = path2polygonPoints(path, 16)

--- a/pysrc/svg_load/path2polygon.py
+++ b/pysrc/svg_load/path2polygon.py
@@ -1,4 +1,3 @@
-from svg.path import parse_path
 import numpy as np
 from numpy.linalg import norm
 
@@ -23,7 +22,6 @@ def c2a(c: complex):
 
 
 def path2polygonPoints(path, step):
-	path = parse_path(path)
 	corner_count = 0
 	points = []
 	path_length = path.length()
@@ -67,23 +65,4 @@ def print_samples(points, name="test"):
 	output += f"addToPointLibrary(\"{name}\", {name}, (sizeof({name})/sizeof(*{name})), "
 	output += f"{(left_most_x * 100):.0f}, {(right_most_x * 100):.0f} ); //{len(points)} points"
 	return output
-
-
-if __name__ == "__main__":
-	points = path2polygonPoints(
-		"""M 34.617417,71.75 34.5,4.8522527 C 52.261339,3.5455972 67.416136,2.6942001 65.808439,23.35372 64.952019,34.359041 57.615914,40.960017 42.78125,40.8125"""
-		, 13)
-	print(points)
-	result = print_samples(points, "charP")
-	print(result)
-	expected = """int charP[] = 
-	{Point(865, 1794), Point(865, 1631), Point(865, 1469), Point(865, 1306), 
-	Point(864, 1144), Point(864, 981), Point(864, 819), Point(863, 656), 
-	Point(863, 494), Point(863, 331), Point(863, 169), Point(863, 131), 
-	Point(865, 121), Point(878, 120), Point(977, 113), Point(1140, 107), 
-	Point(1302, 115), Point(1458, 156), Point(1583, 257), Point(1640, 408), 
-	Point(1646, 570), Point(1615, 729), Point(1531, 867), Point(1400, 961), 
-	Point(1245, 1007), Point(1083, 1020), Point(1070, 1020)};
-	addToPointLibrary("charP", charP, (sizeof(charP)/sizeof(*charP)), 3450, 6585); //27 points"""
-	#assert result.strip() == expected.strip(), "result does not match expected output"
 


### PR DESCRIPTION
rename module svg to svg_load
path2polygonPoints expects a Path object now instead of a string
load_svg now returns a Path object instead of a string